### PR TITLE
Send notification on end of candidates

### DIFF
--- a/webrtc.js
+++ b/webrtc.js
@@ -396,6 +396,7 @@ Peer.prototype.onIceCandidate = function (candidate) {
     if (candidate) {
         this.send('candidate', candidate);
     } else {
+        this.send('end-of-candidates');
         this.logger.log("End of candidates.");
     }
 };


### PR DESCRIPTION
This is required in some situations, for example when the signaling API requires a complete SDP instead of accepting ICE candidates as-you-go. If the completion event is dropped, the SDP is never sent out.
I suggest to either send a different message (proposed here), which has the advantage of not breaking the existing API for this module, or to do it the WebRTC way:

```
this.send('candidate');
```
