### PR TITLE
Removed unused config parameters

### DIFF
--- a/webrtc.js
+++ b/webrtc.js
@@ -12,9 +12,6 @@ function WebRTC(opts) {
     var options = opts || {};
     var config = this.config = {
             debug: false,
-            localVideoEl: '',
-            remoteVideosEl: '',
-            autoRequestMedia: false,
             // makes the entire PC config overridable
             peerConnectionConfig: {
                 iceServers: [{"url": "stun:stun.l.google.com:19302"}]


### PR DESCRIPTION
These parameters are used by simplewebrtc, but not by webrtc.
